### PR TITLE
Upgrade docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GLIBC_VER=2.31-r0
 # install glibc compatibility for alpine
 RUN apk add --no-cache --virtual .build-deps \
     binutils \
-    curl 
+    curl
 RUN curl -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub
 RUN curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-${GLIBC_VER}.apk
 RUN curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk
@@ -14,11 +14,11 @@ RUN apk add --no-cache \
     glibc-bin-${GLIBC_VER}.apk
 
 RUN apk -U add groff less python py-pip
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" 
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 
-FROM docker:17-git 
+FROM docker:20-git
 RUN apk add --no-cache \
     curl \
     openssl \


### PR DESCRIPTION
**Context**
I am getting an [error](https://github.com/yarnpkg/yarn/issues/8473) when building after upgrading Soxhub-api to Node 14-LTS. A potential [fix](https://github.com/yarnpkg/yarn/issues/8389) is to upgrade docker.


Naive test. Will be using against Node upgrade PR to validate. https://github.com/soxhub/soxhub-api/pull/6424
![image](https://user-images.githubusercontent.com/8593005/105375155-53ee3a00-5bbd-11eb-9a0c-ef1016eb84b5.png)
